### PR TITLE
Implement ACEF II Risk Score

### DIFF
--- a/CALC_LIST.md
+++ b/CALC_LIST.md
@@ -100,7 +100,7 @@
 ### ✅ ACC/AHA Heart Failure Staging
 **Description:** Describes heart failure stages and provides stage-specific therapy recommendations.
 
-### ACEF II Risk Score for Cardiac Surgery
+### ✅ ACEF II Risk Score for Cardiac Surgery
 **Description:** Predicts 30-day mortality after elective or emergency cardiac surgery.
 
 ### ACEP ED COVID-19 Management Tool

--- a/app/models/scores/__init__.py
+++ b/app/models/scores/__init__.py
@@ -38,8 +38,10 @@ __all__ = [
     # Cardiology
     "Cha2ds2VascRequest",
     "Cha2ds2VascResponse",
-    "AccAhaHfStagingRequest", 
+    "AccAhaHfStagingRequest",
     "AccAhaHfStagingResponse",
+    "AcefIiRequest",
+    "AcefIiResponse",
     
     # Pulmonology
     "Curb65Request",

--- a/app/models/scores/cardiology/__init__.py
+++ b/app/models/scores/cardiology/__init__.py
@@ -4,10 +4,13 @@ Cardiology score models
 
 from .cha2ds2_vasc import Cha2ds2VascRequest, Cha2ds2VascResponse
 from .acc_aha_hf_staging import AccAhaHfStagingRequest, AccAhaHfStagingResponse
+from .acef_ii import AcefIiRequest, AcefIiResponse
 
 __all__ = [
     "Cha2ds2VascRequest",
     "Cha2ds2VascResponse",
     "AccAhaHfStagingRequest",
-    "AccAhaHfStagingResponse"
+    "AccAhaHfStagingResponse",
+    "AcefIiRequest",
+    "AcefIiResponse"
 ]

--- a/app/models/scores/cardiology/acef_ii.py
+++ b/app/models/scores/cardiology/acef_ii.py
@@ -1,0 +1,60 @@
+"""ACEF II Risk Score models"""
+
+from pydantic import BaseModel, Field
+
+
+class AcefIiRequest(BaseModel):
+    """Request model for ACEF II Risk Score
+
+    The ACEF II score predicts 30-day mortality after cardiac surgery using
+    patient age, left ventricular ejection fraction, serum creatinine, urgency
+    of the procedure, and pre-operative anemia. The equation is parsimonious
+    yet well validated in contemporary cohorts.
+
+    **Reference**: Ranucci M, Pistuddi V, Scolletta S, de Vincentiis C,
+    Menicanti L. The ACEF II Risk Score for cardiac surgery: updated but still
+    parsimonious. Eur Heart J. 2018;39(23):2183-2189.
+    """
+
+    age: int = Field(..., ge=18, le=100,
+                     description="Patient age in years")
+    ejection_fraction: float = Field(..., ge=10, le=80,
+                                     description="Left ventricular ejection fraction percentage")
+    serum_creatinine: float = Field(..., ge=0.1, le=20.0,
+                                    description="Serum creatinine in mg/dL")
+    emergency_surgery: bool = Field(..., description="Emergency surgery indicator")
+    hematocrit: float = Field(..., ge=15, le=60,
+                              description="Pre-operative hematocrit percentage")
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "age": 70,
+                "ejection_fraction": 45.0,
+                "serum_creatinine": 1.2,
+                "emergency_surgery": False,
+                "hematocrit": 38.0
+            }
+        }
+
+
+class AcefIiResponse(BaseModel):
+    """Response model for ACEF II Risk Score"""
+
+    result: float = Field(..., description="ACEF II score")
+    unit: str = Field(..., description="Unit of the result")
+    interpretation: str = Field(..., description="Clinical interpretation")
+    stage: str = Field(..., description="Risk category")
+    stage_description: str = Field(..., description="Risk description")
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "result": 1.8,
+                "unit": "points",
+                "interpretation": "Standard perioperative management.",
+                "stage": "Low Risk",
+                "stage_description": "Estimated mortality <2%"
+            }
+        }
+

--- a/app/routers/scores/cardiology/__init__.py
+++ b/app/routers/scores/cardiology/__init__.py
@@ -6,9 +6,11 @@ from fastapi import APIRouter
 
 from .cha2ds2_vasc import router as cha2ds2_vasc_router
 from .acc_aha_hf_staging import router as acc_aha_hf_staging_router
+from .acef_ii import router as acef_ii_router
 
 # Create main specialty router
 router = APIRouter()
 
 router.include_router(cha2ds2_vasc_router)
 router.include_router(acc_aha_hf_staging_router)
+router.include_router(acef_ii_router)

--- a/app/routers/scores/cardiology/acef_ii.py
+++ b/app/routers/scores/cardiology/acef_ii.py
@@ -1,0 +1,42 @@
+"""ACEF II Risk Score router"""
+
+from fastapi import APIRouter, HTTPException
+from app.models.scores.cardiology import AcefIiRequest, AcefIiResponse
+from app.services.calculator_service import calculator_service
+
+router = APIRouter()
+
+@router.post(
+    "/acef_ii",
+    response_model=AcefIiResponse,
+    summary="Calculate ACEF II Risk Score",
+    description="Predicts 30-day mortality after cardiac surgery",
+    response_description="Calculated ACEF II score with risk interpretation",
+)
+async def calculate_acef_ii(request: AcefIiRequest):
+    """Calculate ACEF II Risk Score"""
+    try:
+        params = {
+            "age": request.age,
+            "ejection_fraction": request.ejection_fraction,
+            "serum_creatinine": request.serum_creatinine,
+            "emergency_surgery": request.emergency_surgery,
+            "hematocrit": request.hematocrit,
+        }
+        result = calculator_service.calculate_score("acef_ii", params)
+        if result is None:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": "CalculationError",
+                    "message": "Error calculating ACEF II",
+                    "details": {"parameters": params},
+                },
+            )
+        return AcefIiResponse(**result)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail={"error": "ValidationError", "message": str(e)})
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail={"error": "InternalServerError", "message": str(e)})

--- a/calculators/acef_ii.py
+++ b/calculators/acef_ii.py
@@ -1,0 +1,78 @@
+"""ACEF II Risk Score Calculator
+
+Calculates predicted operative mortality risk after cardiac surgery
+based on age, ejection fraction, serum creatinine, emergency status,
+and pre-operative anemia.
+
+Reference: Ranucci M et al. Eur Heart J. 2018;39(23):2183-2189.
+"""
+
+from typing import Dict, Any
+
+
+class AcefIiCalculator:
+    """Calculator for ACEF II Risk Score"""
+
+    def calculate(self, age: int, ejection_fraction: float, serum_creatinine: float,
+                 emergency_surgery: bool, hematocrit: float) -> Dict[str, Any]:
+        self._validate_inputs(age, ejection_fraction, serum_creatinine, hematocrit)
+
+        score = age / ejection_fraction
+
+        if serum_creatinine > 2:
+            score += 2
+
+        if emergency_surgery:
+            score += 3
+
+        if hematocrit < 36:
+            score += 0.2 * (36 - hematocrit)
+
+        score = round(score, 2)
+
+        interpretation = self._get_interpretation(score)
+
+        return {
+            "result": score,
+            "unit": "points",
+            "interpretation": interpretation["interpretation"],
+            "stage": interpretation["stage"],
+            "stage_description": interpretation["description"],
+        }
+
+    def _validate_inputs(self, age: int, ef: float, creat: float, hct: float):
+        if not 18 <= age <= 100:
+            raise ValueError("Age must be between 18 and 100 years")
+        if not 10 <= ef <= 80:
+            raise ValueError("Ejection fraction must be between 10 and 80%")
+        if creat <= 0 or creat > 20:
+            raise ValueError("Serum creatinine must be between 0 and 20 mg/dL")
+        if not 15 <= hct <= 60:
+            raise ValueError("Hematocrit must be between 15 and 60%")
+
+    def _get_interpretation(self, score: float) -> Dict[str, str]:
+        if score < 2:
+            return {
+                "stage": "Low Risk",
+                "description": "Estimated mortality <2%",
+                "interpretation": "Standard perioperative management.",
+            }
+        elif score < 3:
+            return {
+                "stage": "Intermediate Risk",
+                "description": "Estimated mortality 2-5%",
+                "interpretation": "Optimize comorbidities and monitor carefully.",
+            }
+        else:
+            return {
+                "stage": "High Risk",
+                "description": "Estimated mortality >5%",
+                "interpretation": "Enhanced monitoring and risk-benefit discussion recommended.",
+            }
+
+
+def calculate_acef_ii(age: int, ejection_fraction: float, serum_creatinine: float,
+                      emergency_surgery: bool, hematocrit: float) -> Dict[str, Any]:
+    """Convenience wrapper for dynamic loader"""
+    calc = AcefIiCalculator()
+    return calc.calculate(age, ejection_fraction, serum_creatinine, emergency_surgery, hematocrit)

--- a/scores/acef_ii.json
+++ b/scores/acef_ii.json
@@ -1,0 +1,70 @@
+{
+  "id": "acef_ii",
+  "title": "ACEF II Risk Score for Cardiac Surgery",
+  "description": "Predicts 30-day mortality after elective or emergency cardiac surgery, incorporating age, creatinine, ejection fraction, emergency status, and pre-operative anemia.",
+  "category": "cardiology",
+  "version": "2018",
+  "parameters": [
+    {
+      "name": "age",
+      "type": "integer",
+      "required": true,
+      "description": "Patient age",
+      "validation": {"min": 18, "max": 100},
+      "unit": "years"
+    },
+    {
+      "name": "ejection_fraction",
+      "type": "float",
+      "required": true,
+      "description": "Left ventricular ejection fraction percentage",
+      "validation": {"min": 10, "max": 80},
+      "unit": "%"
+    },
+    {
+      "name": "serum_creatinine",
+      "type": "float",
+      "required": true,
+      "description": "Serum creatinine",
+      "validation": {"min": 0.1, "max": 20.0},
+      "unit": "mg/dL"
+    },
+    {
+      "name": "emergency_surgery",
+      "type": "boolean",
+      "required": true,
+      "description": "Emergency surgery indicator"
+    },
+    {
+      "name": "hematocrit",
+      "type": "float",
+      "required": true,
+      "description": "Pre-operative hematocrit",
+      "validation": {"min": 15, "max": 60},
+      "unit": "%"
+    }
+  ],
+  "result": {
+    "name": "acef_ii_score",
+    "type": "float",
+    "unit": "points",
+    "description": "Calculated ACEF II score"
+  },
+  "interpretation": {
+    "ranges": [
+      {"min": 0, "max": 2, "stage": "Low Risk", "description": "Estimated mortality <2%", "interpretation": "Proceed with standard perioperative management."},
+      {"min": 2, "max": 3, "stage": "Intermediate Risk", "description": "Estimated mortality 2-5%", "interpretation": "Consider optimization of comorbidities and careful monitoring."},
+      {"min": 3, "max": 99, "stage": "High Risk", "description": "Estimated mortality >5%", "interpretation": "Enhanced perioperative monitoring and risk-benefit discussion recommended."}
+    ]
+  },
+  "references": [
+    "Ranucci M, Pistuddi V, Scolletta S, de Vincentiis C, Menicanti L. The ACEF II Risk Score for cardiac surgery: updated but still parsimonious. Eur Heart J. 2018;39(23):2183-2189."
+  ],
+  "formula": "ACEF II = age / ejection fraction + [2 if serum_creatinine > 2 mg/dL] + [3 if emergency surgery] + [0.2 × (36 - hematocrit) if hematocrit < 36]",
+  "notes": [
+    "Designed for elective and emergency cardiac surgery patients.",
+    "Predicts operative mortality within 30 days.",
+    "Anemia penalty applies when hematocrit is below 36%: add 0.2 points for each percent below 36%.",
+    "Higher scores indicate increased operative mortality risk."
+  ]
+}


### PR DESCRIPTION
## Summary
- add ACEF II risk score metadata
- implement calculator logic for ACEF II
- create request/response models
- add router endpoint
- expose models and router via `__init__`
- mark ACEF II as complete in list
- include Vancouver style reference in Pydantic model

## Testing
- `python -m compileall -q calculators app`

------
https://chatgpt.com/codex/tasks/task_e_68879312cfdc8331a0d36ca264ddf6b0