### PR TITLE
Add ACEP ED COVID-19 Management Tool

### DIFF
--- a/CALC_LIST.md
+++ b/CALC_LIST.md
@@ -103,7 +103,7 @@
 ### ✅ ACEF II Risk Score for Cardiac Surgery
 **Description:** Predicts 30-day mortality after elective or emergency cardiac surgery.
 
-### ACEP ED COVID-19 Management Tool
+### ✅ ACEP ED COVID-19 Management Tool
 **Description:** Emergency department triage and management tool for adult (age >18) patients with suspected or confirmed SARS-CoV-2.
 
 ### Acetaminophen Overdose and NAC Dosing

--- a/app/models/scores/__init__.py
+++ b/app/models/scores/__init__.py
@@ -68,6 +68,8 @@ __all__ = [
     # Emergency Medicine
     "FourCMortalityRequest",
     "FourCMortalityResponse",
+    "AcepEdCovid19ManagementToolRequest",
+    "AcepEdCovid19ManagementToolResponse",
     
     # Psychiatry
     "AasRequest",

--- a/app/models/scores/emergency/__init__.py
+++ b/app/models/scores/emergency/__init__.py
@@ -6,6 +6,10 @@ from .four_c_mortality import FourCMortalityRequest, FourCMortalityResponse
 from .ais_inhalation_injury import AisInhalationInjuryRequest, AisInhalationInjuryResponse
 from .emergency_medicine_coding_guide_2023 import EmergencyMedicineCodingGuide2023Request, EmergencyMedicineCodingGuide2023Response
 from .abc_score import AbcScoreRequest, AbcScoreResponse
+from .acep_ed_covid19_management_tool import (
+    AcepEdCovid19ManagementToolRequest,
+    AcepEdCovid19ManagementToolResponse,
+)
 
 __all__ = [
     "FourCMortalityRequest",
@@ -16,4 +20,6 @@ __all__ = [
     "EmergencyMedicineCodingGuide2023Response",
     "AbcScoreRequest",
     "AbcScoreResponse",
+    "AcepEdCovid19ManagementToolRequest",
+    "AcepEdCovid19ManagementToolResponse",
 ]

--- a/app/models/scores/emergency/acep_ed_covid19_management_tool.py
+++ b/app/models/scores/emergency/acep_ed_covid19_management_tool.py
@@ -1,0 +1,73 @@
+"""Models for ACEP ED COVID-19 Management Tool"""
+
+from typing import Optional
+from pydantic import BaseModel, Field
+from typing_extensions import Literal
+
+from app.models.shared import YesNoType
+
+
+class AcepEdCovid19ManagementToolRequest(BaseModel):
+    """Request model for ACEP ED COVID-19 Management Tool
+
+    Provides parameters required to determine recommended disposition for adults with
+    suspected or confirmed SARS-CoV-2 infection in the emergency department. The
+    tool integrates NIH severity classification with the PRIEST score and patient
+    risk factors to guide diagnostic workup and management.
+
+    References:
+    1. American College of Emergency Physicians. ACEP Emergency Department COVID-19 Management Tool. Fall 2023.
+    2. MDCalc. ACEP ED COVID-19 Management Tool. https://www.mdcalc.com/calc/10333/acep-ed-covid-19-management-tool
+    """
+
+    severity: Literal["mild", "moderate", "severe", "critical"] = Field(
+        ..., description="Clinical severity based on NIH criteria"
+    )
+    priest_score: int = Field(
+        ..., ge=0, le=30, description="PRIEST score estimating risk of adverse outcome"
+    )
+    risk_factors: int = Field(
+        ..., ge=0, le=20, description="Number of high-risk comorbid conditions"
+    )
+    imaging_concerning: YesNoType = Field(
+        ..., description="Presence of concerning imaging findings"
+    )
+    labs_concerning: YesNoType = Field(
+        ..., description="Presence of concerning laboratory results"
+    )
+    self_care_capable: YesNoType = Field(
+        ..., description="Patient able to care for self and has adequate resources at home"
+    )
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "severity": "mild",
+                "priest_score": 3,
+                "risk_factors": 0,
+                "imaging_concerning": "no",
+                "labs_concerning": "no",
+                "self_care_capable": "yes",
+            }
+        }
+
+
+class AcepEdCovid19ManagementToolResponse(BaseModel):
+    """Response model for ACEP ED COVID-19 Management Tool"""
+
+    result: str = Field(..., description="Recommended disposition")
+    unit: str = Field(..., description="Unit of the result")
+    interpretation: str = Field(..., description="Clinical interpretation")
+    stage: str = Field(..., description="Disposition classification")
+    stage_description: str = Field(..., description="Short description of disposition level")
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "result": "Discharge",
+                "unit": "disposition",
+                "interpretation": "Safe for discharge with return precautions and follow-up.",
+                "stage": "Discharge",
+                "stage_description": "Mild disease with low risk of progression",
+            }
+        }

--- a/app/routers/scores/emergency/__init__.py
+++ b/app/routers/scores/emergency/__init__.py
@@ -8,6 +8,7 @@ from .four_c_mortality import router as four_c_mortality_router
 from .ais_inhalation_injury import router as ais_inhalation_injury_router
 from .emergency_medicine_coding_guide_2023 import router as emergency_medicine_coding_guide_2023_router
 from .abc_score import router as abc_score_router
+from .acep_ed_covid19_management_tool import router as acep_ed_covid19_management_tool_router
 
 # Create main specialty router
 router = APIRouter()
@@ -16,3 +17,4 @@ router.include_router(four_c_mortality_router)
 router.include_router(ais_inhalation_injury_router)
 router.include_router(emergency_medicine_coding_guide_2023_router)
 router.include_router(abc_score_router)
+router.include_router(acep_ed_covid19_management_tool_router)

--- a/app/routers/scores/emergency/acep_ed_covid19_management_tool.py
+++ b/app/routers/scores/emergency/acep_ed_covid19_management_tool.py
@@ -1,0 +1,57 @@
+"""Router for ACEP ED COVID-19 Management Tool"""
+
+from fastapi import APIRouter, HTTPException
+from app.models.scores.emergency import (
+    AcepEdCovid19ManagementToolRequest,
+    AcepEdCovid19ManagementToolResponse,
+)
+from app.services.calculator_service import calculator_service
+
+router = APIRouter()
+
+
+@router.post(
+    "/acep_ed_covid19_management_tool",
+    response_model=AcepEdCovid19ManagementToolResponse,
+    summary="ACEP ED COVID-19 Management Tool",
+    description="Determines recommended disposition for suspected or confirmed COVID-19 in adults",
+    response_description="Disposition recommendation with interpretation",
+)
+async def calculate_acep_ed_covid19_management_tool(
+    request: AcepEdCovid19ManagementToolRequest,
+):
+    """Calculate ACEP ED COVID-19 Management Tool"""
+    try:
+        params = {
+            "severity": request.severity,
+            "priest_score": request.priest_score,
+            "risk_factors": request.risk_factors,
+            "imaging_concerning": request.imaging_concerning == "yes",
+            "labs_concerning": request.labs_concerning == "yes",
+            "self_care_capable": request.self_care_capable == "yes",
+        }
+        result = calculator_service.calculate_score(
+            "acep_ed_covid19_management_tool", params
+        )
+        if result is None:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": "CalculationError",
+                    "message": "Error calculating ACEP ED COVID-19 Management Tool",
+                    "details": {"parameters": params},
+                },
+            )
+        return AcepEdCovid19ManagementToolResponse(**result)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "ValidationError", "message": str(e)},
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "InternalServerError", "message": str(e)},
+        )

--- a/calculators/acep_ed_covid19_management_tool.py
+++ b/calculators/acep_ed_covid19_management_tool.py
@@ -1,0 +1,147 @@
+"""ACEP ED COVID-19 Management Tool Calculator
+
+Simplified implementation of the ACEP Emergency Department COVID-19 Management Tool (Fall 2023).
+Determines recommended disposition for adult patients with suspected or confirmed SARS-CoV-2
+based on severity, PRIEST score, and risk factor assessment.
+
+Reference: American College of Emergency Physicians. ACEP Emergency Department COVID-19 Management Tool. Fall 2023.
+"""
+
+from typing import Dict, Any
+
+
+class AcepEdCovid19ManagementToolCalculator:
+    """Calculator for ACEP ED COVID-19 Management Tool"""
+
+    VALID_SEVERITIES = ["mild", "moderate", "severe", "critical"]
+
+    def calculate(
+        self,
+        severity: str,
+        priest_score: int,
+        risk_factors: int,
+        imaging_concerning: bool,
+        labs_concerning: bool,
+        self_care_capable: bool,
+    ) -> Dict[str, Any]:
+        self._validate_inputs(
+            severity,
+            priest_score,
+            risk_factors,
+            imaging_concerning,
+            labs_concerning,
+            self_care_capable,
+        )
+
+        disposition = self._determine_disposition(
+            severity,
+            priest_score,
+            risk_factors,
+            imaging_concerning,
+            labs_concerning,
+            self_care_capable,
+        )
+
+        interpretation = self._get_interpretation(disposition)
+
+        return {
+            "result": disposition["stage"],
+            "unit": "disposition",
+            "interpretation": interpretation["interpretation"],
+            "stage": interpretation["stage"],
+            "stage_description": interpretation["description"],
+        }
+
+    def _validate_inputs(
+        self,
+        severity: str,
+        priest_score: int,
+        risk_factors: int,
+        imaging_concerning: bool,
+        labs_concerning: bool,
+        self_care_capable: bool,
+    ) -> None:
+        if severity not in self.VALID_SEVERITIES:
+            raise ValueError("Severity must be 'mild', 'moderate', 'severe', or 'critical'")
+        if not isinstance(priest_score, int) or not 0 <= priest_score <= 30:
+            raise ValueError("PRIEST score must be between 0 and 30")
+        if not isinstance(risk_factors, int) or not 0 <= risk_factors <= 20:
+            raise ValueError("Risk factors must be between 0 and 20")
+        if not isinstance(imaging_concerning, bool):
+            raise ValueError("imaging_concerning must be boolean")
+        if not isinstance(labs_concerning, bool):
+            raise ValueError("labs_concerning must be boolean")
+        if not isinstance(self_care_capable, bool):
+            raise ValueError("self_care_capable must be boolean")
+
+    def _determine_disposition(
+        self,
+        severity: str,
+        priest_score: int,
+        risk_factors: int,
+        imaging_concerning: bool,
+        labs_concerning: bool,
+        self_care_capable: bool,
+    ) -> Dict[str, str]:
+        if severity == "critical":
+            return {"stage": "ICU"}
+        if severity == "severe":
+            return {"stage": "Admission"}
+
+        # mild or moderate
+        if (
+            severity == "mild"
+            and priest_score <= 4
+            and risk_factors <= 1
+            and not imaging_concerning
+            and not labs_concerning
+            and self_care_capable
+        ):
+            return {"stage": "Discharge"}
+        return {"stage": "Admission/Observation"}
+
+    def _get_interpretation(self, disposition: Dict[str, str]) -> Dict[str, str]:
+        stage = disposition["stage"]
+        if stage == "ICU":
+            return {
+                "stage": "ICU",
+                "description": "Critical illness requiring intensive care",
+                "interpretation": "Immediate ICU admission. Consider transfer for ECMO or advanced therapies.",
+            }
+        if stage == "Admission":
+            return {
+                "stage": "Admission",
+                "description": "Severe disease requiring hospitalization",
+                "interpretation": "Hospital admission recommended; level of care based on clinical judgment.",
+            }
+        if stage == "Discharge":
+            return {
+                "stage": "Discharge",
+                "description": "Mild disease with low risk of progression",
+                "interpretation": "Safe for discharge with return precautions and follow-up.",
+            }
+        return {
+            "stage": "Admission/Observation",
+            "description": "Mild or moderate illness with risk factors",
+            "interpretation": "Consider admission or observation depending on risk assessment and resources.",
+        }
+
+
+def calculate_acep_ed_covid19_management_tool(
+    severity: str,
+    priest_score: int,
+    risk_factors: int,
+    imaging_concerning: bool,
+    labs_concerning: bool,
+    self_care_capable: bool,
+) -> Dict[str, Any]:
+    """Convenience wrapper for dynamic import system"""
+    calc = AcepEdCovid19ManagementToolCalculator()
+    return calc.calculate(
+        severity,
+        priest_score,
+        risk_factors,
+        imaging_concerning,
+        labs_concerning,
+        self_care_capable,
+    )

--- a/scores/acep_ed_covid19_management_tool.json
+++ b/scores/acep_ed_covid19_management_tool.json
@@ -1,0 +1,34 @@
+{
+  "id": "acep_ed_covid19_management_tool",
+  "title": "ACEP ED COVID-19 Management Tool",
+  "description": "Provides disposition guidance for adult ED patients with suspected or confirmed SARS-CoV-2 using severity classification, PRIEST score, and risk factors.",
+  "category": "emergency",
+  "version": "2023",
+  "parameters": [
+    {"name": "severity", "type": "string", "required": true, "description": "Clinical severity category", "options": ["mild", "moderate", "severe", "critical"], "validation": {"enum": ["mild", "moderate", "severe", "critical"]}},
+    {"name": "priest_score", "type": "integer", "required": true, "description": "PRIEST score", "validation": {"min": 0, "max": 30}},
+    {"name": "risk_factors", "type": "integer", "required": true, "description": "Number of high-risk comorbidities", "validation": {"min": 0, "max": 20}},
+    {"name": "imaging_concerning", "type": "boolean", "required": true, "description": "Concerning imaging findings"},
+    {"name": "labs_concerning", "type": "boolean", "required": true, "description": "Concerning laboratory results"},
+    {"name": "self_care_capable", "type": "boolean", "required": true, "description": "Patient able to care for self at home"}
+  ],
+  "result": {"name": "recommended_disposition", "type": "string", "unit": "disposition", "description": "Recommended level of care"},
+  "interpretation": {
+    "ranges": [
+      {"min": 0, "max": 0, "stage": "Discharge", "description": "Mild disease with low risk", "interpretation": "Safe for discharge with education and follow-up."},
+      {"min": 1, "max": 1, "stage": "Admission/Observation", "description": "Mild or moderate disease with risk factors", "interpretation": "Consider admission or observation."},
+      {"min": 2, "max": 2, "stage": "Admission", "description": "Severe disease", "interpretation": "Hospital admission recommended."},
+      {"min": 3, "max": 3, "stage": "ICU", "description": "Critical illness", "interpretation": "Immediate ICU admission or transfer."}
+    ]
+  },
+  "references": [
+    "American College of Emergency Physicians. ACEP Emergency Department COVID-19 Management Tool. Fall 2023.",
+    "MDCalc. ACEP ED COVID-19 Management Tool. Available at: https://www.mdcalc.com/calc/10333/acep-ed-covid-19-management-tool"
+  ],
+  "formula": "Disposition based on severity category, PRIEST score, and risk factors per ACEP guidelines.",
+  "notes": [
+    "Designed for adults ≥18 years presenting with suspected or confirmed COVID-19.",
+    "Uses NIH severity criteria and PRIEST score to guide workup and disposition.",
+    "Home care possible when mild severity, low PRIEST score, minimal comorbidities, and no concerning findings."
+  ]
+}


### PR DESCRIPTION
## Summary
- implement ACEP ED COVID-19 Management Tool calculator
- add request and response models with scientific context and references
- expose new endpoint in emergency routers
- register models and router in package initializers
- provide metadata JSON
- mark calculator as completed in CALC_LIST

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
from app.services.score_service import score_service
from app.services.calculator_service import calculator_service
metadata = score_service.get_score_metadata('acep_ed_covid19_management_tool')
print('metadata title:', metadata.title)
result = calculator_service.calculate_score('acep_ed_covid19_management_tool', {
    'severity': 'mild',
    'priest_score': 3,
    'risk_factors': 0,
    'imaging_concerning': False,
    'labs_concerning': False,
    'self_care_capable': True
})
print(result)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6887a56d8c74833181a863b6652696a1