### PR TITLE
Fix attention_months enum value in calculator API

### DIFF
--- a/app/models/score_models.py
+++ b/app/models/score_models.py
@@ -2451,7 +2451,7 @@ class AlertnessType(str, Enum):
 class AttentionMonthsType(str, Enum):
     """Enum for attention test with months"""
     SEVEN_OR_MORE = "7_or_more"
-    STARTS_LESS_THAN_7 = "starts_less_than_7"
+    STARTS_BUT_LESS_7 = "starts_but_less_7"
     REFUSES_UNTESTABLE = "refuses_untestable"
 
 

--- a/calculators/four_at.py
+++ b/calculators/four_at.py
@@ -20,7 +20,7 @@ class FourAtCalculator:
             alertness: Alertness level ("normal", "altered")
             amt4_errors: Number of errors in AMT4 (0-4)
             attention_months: Performance on attention test 
-                            ("7_or_more", "starts_less_than_7", "refuses_untestable")
+                            ("7_or_more", "starts_but_less_7", "refuses_untestable")
             acute_change: Acute change or fluctuating course ("absent", "present")
             
         Returns:
@@ -61,7 +61,7 @@ class FourAtCalculator:
         if not isinstance(amt4_errors, int) or amt4_errors < 0 or amt4_errors > 4:
             raise ValueError("AMT4 errors must be an integer between 0 and 4")
         
-        valid_attention = ["7_or_more", "starts_less_than_7", "refuses_untestable"]
+        valid_attention = ["7_or_more", "starts_but_less_7", "refuses_untestable"]
         if attention_months not in valid_attention:
             raise ValueError(f"Attention must be: {', '.join(valid_attention)}")
         
@@ -89,7 +89,7 @@ class FourAtCalculator:
         """Scores attention test (months in reverse order)"""
         if attention_months == "7_or_more":
             return 0
-        elif attention_months == "starts_less_than_7":
+        elif attention_months == "starts_but_less_7":
             return 1
         elif attention_months == "refuses_untestable":
             return 2

--- a/scores/four_at.json
+++ b/scores/four_at.json
@@ -31,9 +31,9 @@
       "type": "string",
       "required": true,
       "description": "Performance on attention test (months in reverse order)",
-      "options": ["7_or_more", "starts_less_than_7", "refuses_untestable"],
+      "options": ["7_or_more", "starts_but_less_7", "refuses_untestable"],
       "validation": {
-        "enum": ["7_or_more", "starts_less_than_7", "refuses_untestable"]
+        "enum": ["7_or_more", "starts_but_less_7", "refuses_untestable"]
       }
     },
     {


### PR DESCRIPTION
Standardize `attention_months` enum value to `starts_but_less_7` to resolve API validation inconsistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4c56c25-80ae-4c03-ba13-7f93b834b62d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4c56c25-80ae-4c03-ba13-7f93b834b62d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

